### PR TITLE
Don't fail GitHub Actions fast

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and push Docker images
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os:
           - "alpine"


### PR DESCRIPTION
Let whatever builds succeed and push to Docker Hub even if some fail. It's often that at least one of these fails.