### PR TITLE
Remove Python 3.7 and upgrade to poetry 1.6

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -6,7 +6,7 @@ on:
       - "main"
 
 env:
-  POETRY_VERSION: 1.5.1
+  POETRY_VERSION: 1.6.1
 
 jobs:
   generate:
@@ -55,13 +55,6 @@ jobs:
           - "bullseye"
           - "slim"
         version:
-          - "3.7"
-          - "3.7.12"
-          - "3.7.13"
-          - "3.7.14"
-          - "3.7.15"
-          - "3.7.16"
-          - "3.7.17"
           - "3.8"
           - "3.8.12"
           - "3.8.13"

--- a/generate.py
+++ b/generate.py
@@ -5,13 +5,6 @@ from jinja2 import Template
 
 BASE_IMAGES = ["alpine", "buster", "bullseye", "slim"]
 PYTHON_VERSIONS = [
-    "3.7",
-    "3.7.12",
-    "3.7.13",
-    "3.7.14",
-    "3.7.15",
-    "3.7.16",
-    "3.7.17",
     "3.8",
     "3.8.12",
     "3.8.13",
@@ -50,7 +43,7 @@ PYTHON_VERSIONS = [
     "3.11.3",
     "3.11.4",
 ]
-POETRY_VERSION = "1.5.1"
+POETRY_VERSION = "1.6.1"
 
 logging.basicConfig(
     level="INFO", format="%(levelname)s:%(name)s:%(lineno)d:%(message)s"


### PR DESCRIPTION
Poetry 1.6 removes support for Python 3.7 (https://github.com/python-poetry/poetry/releases/tag/1.6.0). This upgrades to poetry 1.6 and removes Python 3.7. The previous PR (https://github.com/duffn/python-poetry/pull/64) was the last build for Python 3.7.